### PR TITLE
Remove custom styling and deprecated code

### DIFF
--- a/assets/stylesheets/login-with-amazon.scss
+++ b/assets/stylesheets/login-with-amazon.scss
@@ -1,3 +1,0 @@
-.btn-social.amazon {
-  background: #515964;
-}

--- a/plugin.rb
+++ b/plugin.rb
@@ -17,4 +17,4 @@ register_svg_icon "fab-amazon"
 ].each { |path| load File.expand_path(path, __FILE__) }
 
 auth_provider authenticator: Auth::LoginWithAmazonAuthenticator.new,
-              icon: 'fab-amazon',
+              icon: 'fab-amazon'

--- a/plugin.rb
+++ b/plugin.rb
@@ -8,11 +8,7 @@
 
 gem 'omniauth-amazon', '1.0.1'
 
-if respond_to?(:register_svg_icon)
-  register_svg_icon "fab-amazon"
-end
-
-register_asset 'stylesheets/login-with-amazon.scss'
+register_svg_icon "fab-amazon"
 
 [
   "../lib/auth/login_with_amazon_authenticator.rb",
@@ -22,4 +18,3 @@ register_asset 'stylesheets/login-with-amazon.scss'
 
 auth_provider authenticator: Auth::LoginWithAmazonAuthenticator.new,
               icon: 'fab-amazon',
-              frame_height: 600


### PR DESCRIPTION
- core's new login box works much better with the default button styling
- register_svg_icon is now in every discourse version
- frame_height is no longer used