### PR TITLE
DEV: Specify enabled_setting

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -6,6 +6,8 @@
 # authors: Alan Tan
 # url: https://github.com/discourse/discourse-login-with-amazon
 
+enabled_site_setting :enable_login_with_amazon
+
 gem "omniauth-amazon", "1.0.1"
 
 register_svg_icon "fab-amazon"


### PR DESCRIPTION
This setting is already used in the LoginWithAmazonAuthenticator, so this is not a functional change. It just means that the setting will show correctly in the admin dashboard.